### PR TITLE
fix: make tables available to php scripts

### DIFF
--- a/db/connexion.php
+++ b/db/connexion.php
@@ -1,10 +1,18 @@
 <?php
+
+require_once __DIR__. '/../vendor/autoload.php';
+if(!isset($dotenv)){
+    $dotenv = Dotenv\Dotenv::createImmutable(__DIR__.'/../');
+    $dotenv->load();
+}
+
 $connection = $_ENV['DB_CONNECTION'];
 $host = $_ENV['DB_HOST'];
 $db_name = $_ENV['DB_DATABASE'];
 $user = $_ENV['DB_USERNAME'];
 $pass = $_ENV['DB_PASSWORD'];
 $charset = $_ENV['DB_CHARSET'];
+
 $dsn = "$connection:host=$host;dbname=$db_name;charset=$charset";
 
 $options = [


### PR DESCRIPTION
The connection code, which allows migrations in addition to the normal operation of the site, has been updated to also load environment data.